### PR TITLE
DB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 |messages_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :users
-- has_many :messages
+- has_many :users, through: :groups_users
+- has_many :groups_users
 
 
 
@@ -37,8 +37,8 @@
 |nickname|string|null: false|
 
 ### Association
-- has_many :groups
-- has_many :messages
+- has_many :groups, through: :groups_users
+- has_many :groups_users
 
 
 
@@ -47,7 +47,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
+|bodyt|ext|null: false|
 |image|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -55,3 +55,6 @@
 ### Association
 - belongs_to :user
 - belongs_to :group
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,24 +1,57 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## groups_usersテーブル
 
-Things you may want to cover:
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-* Ruby version
+### Association
+- belongs_to :user
+- belongs_to :group
 
-* System dependencies
 
-* Configuration
 
-* Database creation
+## groupsテーブル
 
-* Database initialization
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|messages_id|integer|null: false, foreign_key: true|
 
-* How to run the test suite
+### Association
+- has_many :users
+- has_many :messages
 
-* Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
 
-* ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|nickname|string|null: false|
+
+### Association
+- has_many :groups
+- has_many :messages
+
+
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|string|null: false|
+|image|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -18,11 +18,10 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|messages_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :users, through: :groups_users
+- has_many :messages, through: :groups_users
 - has_many :groups_users
 
 
@@ -34,7 +33,7 @@
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|nickname|string|null: false|
+|nickname|string|null: false, index: true|
 
 ### Association
 - has_many :groups, through: :groups_users
@@ -47,10 +46,10 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|bodyt|ext|null: false|
-|image|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|body|text|
+|image|string|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
 
 ### Association
 - has_many :groups, through: :groups_users
-- has_many :messages, through: :groups_users
 - has_many :groups_users
+- has_many :messages
 
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 
 ### Association
 - has_many :groups, through: :groups_users
+- has_many :messages, through: :groups_users
 - has_many :groups_users
 
 


### PR DESCRIPTION
#WHAT
chatspaceのREADMEのDB設定に下記テーブルを追加しまた。
groupsテーブル、usersテーブル、messagesテーブル

#WHY
グループ、ユーザー、メッセージとそれぞれのデータを関連づけ、ユーザーが適切且つ円滑に使用できるようにする為。